### PR TITLE
Fixed extra space in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-**co-redis** is a [node-redis](https://github.com/mranney/node_redis‎) wrapper to be used with [visionmedia's co](https://github.com/visionmedia/co) library.
+**co-redis** is a [node-redis](https://github.com/mranney/node_redis) wrapper to be used with [visionmedia's co](https://github.com/visionmedia/co) library.
 
 [![build status](https://secure.travis-ci.org/mciparelli/co-redis.png)](http://travis-ci.org/mciparelli/co-redis)
 


### PR DESCRIPTION
Fixed url:

``` markdown
[node-redis](https://github.com/mranney/node_redis)
```
