### PR TITLE
Update thenify dependency to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "redis": "^0.12.1"
   },
   "dependencies": {
-    "thenify": "^3.1.0"
+    "thenify": "^3.1.1"
   }
 }


### PR DESCRIPTION
thenify (and co-redis by extension) is broken on Node 4.x. The latest release of thenify (3.1.1) fixes this.

**Refs**
https://github.com/thenables/thenify/pull/9