### PR TITLE
Switch promisify lib from thenify to es6-promisify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.1
+
+Switch promisify lib from `thenify` to `es6-promisify`
+
 # v2.1.0
 
 .batch() support

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var thenify = require('thenify');
+var promisify = require('es6-promisify');
 var EventEmitter = require('events').EventEmitter;
 
 /**
@@ -27,19 +27,19 @@ module.exports = function (client) {
   
   wrap.multi = function (cmds) {
     var multi = client.multi(cmds);
-    multi.exec = thenify(multi.exec);
+    multi.exec = promisify(multi.exec, multi);
     return multi;
   };
 
   wrap.batch = function (cmds) {
     var batch = client.batch(cmds);
-    batch.exec = thenify(batch.exec);
+    batch.exec = promisify(batch.exec, batch);
     return batch;
   };
   
   wrap.pipeline = function(){
     var pipeline = client.pipeline();
-    pipeline.exec = thenify(pipeline.exec);
+    pipeline.exec = promisify(pipeline.exec, pipeline);
     return pipeline;
   };
   
@@ -76,7 +76,7 @@ module.exports = function (client) {
     
     if (nowrap[key]) return;
     if (isCommand) {
-      protoFunction = thenify(protoFunction);
+      protoFunction = promisify(protoFunction, client);
     }
     wrap[key] = protoFunction;
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "co-redis",
   "description": "A node-redis wrapper to be used with visionmedia's co library",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Martín Ciparelli",
     "email": "mciparelli@gmail.com"
@@ -38,6 +38,6 @@
     "redis": "^2.2.5"
   },
   "dependencies": {
-    "thenify": "^3.1.1"
+    "es6-promisify": "^4.1.0"
   }
 }


### PR DESCRIPTION
Thenify lib does not work when running node with `--use_strict` due to its use of `eval()`. This PR switches the promisify lib to [es6-promisify](https://github.com/digitaldesignlabs/es6-promisify) which does not use `eval()` and also has more stars (if that makes any difference).
